### PR TITLE
Add CI tests and CompatHelper

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,6 +24,11 @@ jobs:
           - windows-latest
         arch:
           - x64
+        include:
+          - version: '1'
+            os: ubuntu-latest
+            arch: x64
+            coverage: true
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
@@ -43,9 +48,13 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - name: Send coverage
-        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
-        uses: coverallsapp/github-action@master
+        if: matrix.coverage
+      - uses: codecov/codecov-action@v1
+        if: matrix.coverage
         with:
-            github-token: ${{ secrets.GITHUB_TOKEN }}
-            path-to-lcov: ./lcov.info
+          file: lcov.info
+      - uses: coverallsapp/github-action@master
+        if: matrix.coverage
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: lcov.info

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.version == 'nightly' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1'
+          - '1.0'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - name: Send coverage
+        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
+        uses: coverallsapp/github-action@master
+        with:
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            path-to-lcov: ./lcov.info

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,16 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: '00 00 * * *'
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }} # for triggering CI
+        run: julia -e 'using CompatHelper; CompatHelper.main(; subdirs=["", "test"])'

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -1,0 +1,46 @@
+name: IntegrationTest
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+    name: ${{ matrix.package.repo }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - {user: TuringLang, repo: DynamicPPL.jl}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: 1
+          arch: x64
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: Clone Downstream
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
+          path: downstream
+      - name: Load this and run the downstream tests
+        shell: julia --color=yes --project=downstream {0}
+        run: |
+          using Pkg
+          try
+            # force it to use this PR's version of the package
+            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
+            Pkg.update()
+            Pkg.test()  # resolver may fail with test time deps
+          catch err
+            err isa Pkg.Resolve.ResolverError || rethrow()
+            # If we can't resolve that means this is incompatible by SemVer and this is fine
+            # It means we marked this as a breaking change, so we don't need to worry about
+            # Mistakenly introducing a breaking change, as we have intentionally made one
+            @info "Not compatible with this release. No problem." exception=err
+            exit(0)  # Exit immediately, as a success
+          end

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ license = "MIT"
 desc = "Common interfaces for probabilistic programming"
 version = "0.1.2"
 
-
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # AbstractPPL.jl
 
 [![CI](https://github.com/TuringLang/AbstractPPL.jl/workflows/CI/badge.svg?branch=master)](https://github.com/TuringLang/AbstractPPL.jl/actions?query=workflow%3ACI+branch%3Amaster)
+[![IntegrationTest](https://github.com/TuringLang/AbstractPPL.jl/workflows/IntegrationTest/badge.svg?branch=master)](https://github.com/TuringLang/AbstractPPL.jl/actions?query=workflow%3AIntegrationTest+branch%3Amaster)
 [![Coverage Status](https://coveralls.io/repos/github/TuringLang/AbstractPPL.jl/badge.svg?branch=master)](https://coveralls.io/github/TuringLang/AbstractPPL.jl?branch=master)
 [![Codecov](https://codecov.io/gh/TuringLang/AbstractPPL.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/TuringLang/AbstractPPL.jl)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # AbstractPPL.jl
 
+[![CI](https://github.com/TuringLang/AbstractPPL.jl/workflows/CI/badge.svg?branch=master)](https://github.com/TuringLang/AbstractPPL.jl/actions?query=workflow%3ACI+branch%3Amaster)
+[![Coverage Status](https://coveralls.io/repos/github/TuringLang/AbstractPPL.jl/badge.svg?branch=master)](https://coveralls.io/github/TuringLang/AbstractPPL.jl?branch=master)
+[![Codecov](https://codecov.io/gh/TuringLang/AbstractPPL.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/TuringLang/AbstractPPL.jl)
+
 A new light-weight package to factor out interfaces and associated APIs for probabilistic
 programming languages (especially their modelleing languages).  The overall goals are creating an
 abstract type and minimal set of functions that will be supported all model and trace types.  Some

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+Documenter = "0.26.3"
+julia = "1"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@
 if VERSION < v"1.2"
     using Pkg: Pkg
     Pkg.activate(@__DIR__)
-    Pkg.develop(PackageSpec(path=dirname(@__DIR__)))
+    Pkg.develop(Pkg.PackageSpec(; path=dirname(@__DIR__)))
     Pkg.instantiate()
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,11 @@
+# Activate test environment on older Julia versions
+if VERSION < v"1.2"
+    using Pkg: Pkg
+    Pkg.activate(@__DIR__)
+    Pkg.develop(PackageSpec(path=dirname(@__DIR__)))
+    Pkg.instantiate()
+end
+
 using AbstractPPL
 using Documenter
 using Test
@@ -7,9 +15,7 @@ using Test
         DocMeta.setdocmeta!(
             AbstractPPL,
             :DocTestSetup,
-            quote
-            using AbstractPPL
-            end;
+            :(using AbstractPPL);
             recursive=true,
         )
         doctest(AbstractPPL; manual=false)


### PR DESCRIPTION
In addition to this PR, one has to add a SSH deploy key (e.g., by following the instructions here: https://github.com/JuliaRegistries/CompatHelper.jl#122-instructions-for-setting-up-the-ssh-deploy-key) to allow CompatHelper to trigger the CI tests.