### PR TITLE
Provide symbol in `VarName` constructor as type parameter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,8 +3,7 @@ uuid = "7a57a42e-76ec-4ea3-a279-07e840d6d9cf"
 keywords = ["probablistic programming"]
 license = "MIT"
 desc = "Common interfaces for probabilistic programming"
-version = "0.1.2"
-
+version = "0.1.3"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/AbstractPPL.jl
+++ b/src/AbstractPPL.jl
@@ -1,11 +1,5 @@
 module AbstractPPL
 
-
-include("varname.jl")
-include("abstractprobprog.jl")
-include("abstractmodeltrace.jl")
-
-
 # VarName
 export VarName,
     getsym,
@@ -27,5 +21,9 @@ export AbstractProbabilisticProgram
 # Abstract traces
 export AbstractModelTrace
 
+include("varname.jl")
+include("abstractprobprog.jl")
+include("abstractmodeltrace.jl")
+include("deprecations.jl")
 
 end # module

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,2 @@
+@deprecate VarName(sym::Symbol) VarName{sym}()
+@deprecate VarName(sym::Symbol, indexing::Tuple) VarName{sym}(indexing)

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -1,5 +1,5 @@
 """
-    VarName(sym[, indexing=()])
+    VarName{sym}(indexing::Tuple=())
 
 A variable identifier for a symbol `sym` and indices `indexing` in the format
 returned by [`@vinds`](@ref).
@@ -28,9 +28,9 @@ x[Colon(),1][2]
 """
 struct VarName{sym, T<:Tuple}
     indexing::T
-end
 
-VarName(sym::Symbol, indexing::Tuple = ()) = VarName{sym, typeof(indexing)}(indexing)
+    VarName{sym}(indexing::Tuple=()) where {sym} = new{sym,typeof(indexing)}(indexing)
+end
 
 """
     VarName(vn::VarName[, indexing=()])
@@ -46,7 +46,7 @@ x
 ```
 """
 function VarName(vn::VarName, indexing::Tuple = ())
-    return VarName{getsym(vn), typeof(indexing)}(indexing)
+    return VarName{getsym(vn)}(indexing)
 end
 
 
@@ -249,11 +249,11 @@ macro varname(expr::Union{Expr, Symbol})
     return esc(varname(expr))
 end
 
-varname(expr::Symbol) = VarName(expr)
+varname(sym::Symbol) = :($(AbstractPPL.VarName){$(QuoteNode(sym))}())
 function varname(expr::Expr)
     if Meta.isexpr(expr, :ref)
         sym, inds = vsym(expr), vinds(expr)
-        return :($(AbstractPPL.VarName)($(QuoteNode(sym)), $inds))
+        return :($(AbstractPPL.VarName){$(QuoteNode(sym))}($inds))
     else
         throw("Malformed variable name $(expr)!")
     end

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -10,19 +10,19 @@ stores the indices requires to access the random variable from the Julia variabl
 as a tuple of tuples. Each element of the tuple thereby contains the indices of one indexing
 operation.
 
-`VarName`s can be manually constructed using the `VarName(sym, indexing)` constructor, or from an
+`VarName`s can be manually constructed using the `VarName{sym}(indexing)` constructor, or from an
 indexing expression through the [`@varname`](@ref) convenience macro.
 
 # Examples
 
 ```jldoctest
-julia> vn = VarName(:x, ((Colon(), 1), (2,)))
+julia> vn = VarName{:x}(((Colon(), 1), (2,)))
 x[Colon(),1][2]
 
 julia> vn.indexing
 ((Colon(), 1), (2,))
 
-julia> VarName(AbstractPPL.@vsym(x[:, 1][1+1]), AbstractPPL.@vinds(x[:, 1][1+1]))
+julia> @varname x[:, 1][1+1]
 x[Colon(),1][2]
 ```
 """
@@ -33,7 +33,7 @@ struct VarName{sym, T<:Tuple}
 end
 
 """
-    VarName(vn::VarName[, indexing=()])
+    VarName(vn::VarName, indexing=())
 
 Return a copy of `vn` with a new index `indexing`.
 
@@ -269,13 +269,13 @@ For example, `@vsym x[1]` returns `:x`.
 ## Examples
 
 ```jldoctest
-julia> AbstractPPL.@vsym x
+julia> @vsym x
 :x
 
-julia> AbstractPPL.@vsym x[1,1][2,3]
+julia> @vsym x[1,1][2,3]
 :x
 
-julia> AbstractPPL.@vsym x[end]
+julia> @vsym x[end]
 :x
 ```
 """
@@ -307,19 +307,19 @@ Returns a tuple of tuples of the indices in `expr`.
 ## Examples
 
 ```jldoctest
-julia> AbstractPPL.@vinds x
+julia> @vinds x
 ()
 
-julia> AbstractPPL.@vinds x[1,1][2,3]
+julia> @vinds x[1,1][2,3]
 ((1, 1), (2, 3))
 
-julia> AbstractPPL.@vinds x[:,1][2,:]
+julia> @vinds x[:,1][2,:]
 ((Colon(), 1), (2, Colon()))
 
-julia> AbstractPPL.@vinds x[2:3,1][2,1:2]
+julia> @vinds x[2:3,1][2,1:2]
 ((2:3, 1), (2, 1:2))
 
-julia> AbstractPPL.@vinds x[2:3,2:3][[1,2],[1,2]]
+julia> @vinds x[2:3,2:3][[1,2],[1,2]]
 ((2:3, 2:3), ([1, 2], [1, 2]))
 ```
 
@@ -341,10 +341,10 @@ suitable for input of the [`VarName`](@ref) constructor.
 ## Examples
 
 ```jldoctest
-julia> AbstractPPL.vinds(:(x[end]))
+julia> vinds(:(x[end]))
 :((((lastindex)(x),),))
 
-julia> AbstractPPL.vinds(:(x[1, end]))
+julia> vinds(:(x[1, end]))
 :(((1, (lastindex)(x, 2)),))
 ```
 """

--- a/test/deprecations.jl
+++ b/test/deprecations.jl
@@ -1,0 +1,4 @@
+@testset "deprecations.jl" begin
+    @test (@test_deprecated VarName(:x)) == VarName{:x}()
+    @test (@test_deprecated VarName(:x, ((1,), (:, 2)))) == VarName{:x}(((1,), (:, 2)))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,8 @@ using Documenter
 using Test
 
 @testset "AbstractPPL.jl" begin
+    include("deprecations.jl")
+
     @testset "doctests" begin
         DocMeta.setdocmeta!(
             AbstractPPL,


### PR DESCRIPTION
Constant propagation in the `VarName` does not work reliably as we noticed in https://github.com/TuringLang/DynamicPPL.jl/pull/221. Applying the changes in this PR improves performance noticeably.

IMO there is no reason to keep the existing type-unstable constructor. I deprecated it, therefore it is a non-breaking change.