### PR TITLE
Prettier show for `Colon`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "7a57a42e-76ec-4ea3-a279-07e840d6d9cf"
 keywords = ["probablistic programming"]
 license = "MIT"
 desc = "Common interfaces for probabilistic programming"
-version = "0.1.5"
+version = "0.2.0"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "7a57a42e-76ec-4ea3-a279-07e840d6d9cf"
 keywords = ["probablistic programming"]
 license = "MIT"
 desc = "Common interfaces for probabilistic programming"
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -98,8 +98,8 @@ function Base.show(io::IO, vn::VarName)
     end
 end
 
-replace_colon_string(x) = x
-replace_colon_string(::Colon) = ":"
+prettify_index(x) = string(x)
+prettify_index(::Colon) = ":"
 
 """
     Symbol(vn::VarName)

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -93,11 +93,13 @@ function Base.show(io::IO, vn::VarName)
     print(io, getsym(vn))
     for indices in getindexing(vn)
         print(io, "[")
-        join(io, indices, ",")
+        join(io, map(replace_colon_string, indices), ",")
         print(io, "]")
     end
 end
 
+replace_colon_string(x) = x
+replace_colon_string(::Colon) = ":"
 
 """
     Symbol(vn::VarName)

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -17,13 +17,13 @@ indexing expression through the [`@varname`](@ref) convenience macro.
 
 ```jldoctest
 julia> vn = VarName{:x}(((Colon(), 1), (2,)))
-x[Colon(),1][2]
+x[:,1][2]
 
 julia> vn.indexing
 ((Colon(), 1), (2,))
 
 julia> @varname x[:, 1][1+1]
-x[Colon(),1][2]
+x[:,1][2]
 ```
 """
 struct VarName{sym, T<:Tuple}


### PR DESCRIPTION
Currently:

```julia
julia> @varname(x[:,1])
x[Colon(),1]
```

On this branch:

```julia
julia> @varname(x[:,1])
x[:,1]
```

Seems like the latter is preferable, and will make a lot of downstream printing much nicer, e.g. chains obtained in Turing.

Only potential issue is that people might have code that access elements in a chain, etc. using `Colon()` in the string-rep, so maybe this should be a breaking release?