### PR TITLE
Fix begin/end replacement in varname expansion (fixes #23)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "7a57a42e-76ec-4ea3-a279-07e840d6d9cf"
 keywords = ["probablistic programming"]
 license = "MIT"
 desc = "Common interfaces for probabilistic programming"
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -361,21 +361,17 @@ suitable for input of the [`VarName`](@ref) constructor.
 ## Examples
 
 ```jldoctest
-julia> vinds(:(x[end]))
-:((((lastindex)(x),),))
+julia> x = [1]; eval(vinds(:(x[end])))
+((1,),)
 
-julia> vinds(:(x[1, end]))
-:(((1, (lastindex)(x, 2)),))
+julia> x = [1 2]; eval(vinds(:(x[1, end])))
+((1, 2),)
 
-julia> vinds(:(x[1][end]))
-:(let var"##S#321" = x[1]
-      ((1,), ((lastindex)(var"##S#321"),))
-  end)
+julia> x = [[1]]; eval(vinds(:(x[1][end])))
+((1,), (1,))
 
-julia> vinds(:(x[1][2, end, :][3]))
-:(let var"##S#322" = x[1]
-      ((1,), (2, (lastindex)(var"##S#322", 2), :), (3,))
-  end)
+julia> x = [fill([1,2,3], 2,2,2)]; eval(vinds(:(x[begin][2, end, :][3])))
+((1,), (2, 2, Colon()), (3,))
 ```
 """
 function vinds(expr, head = vsym(expr))


### PR DESCRIPTION
The trick is to (1) first extract the indices, then replace the `begin`/`end`, and (2) make use of the internal `Base.replace_ref_(begin_)end_!`, which lets you specify the replacement yourself.

The latter seems a bit dubious, but I don't see another chance without a complete reimplementation of `Base.replace_ref_begin_end!`.  Any kind of recursive implementation will have that argument anyway, since you need to care about nested scopes, so it should be kinda stable... I hope.

I'd also like to include a test of the following kind:

```julia
julia> vinds(:(x[:, a[10][end], :]))
:(((:, let var"##S#266" = a[10]
              var"##S#266"[(lastindex)(var"##S#266")]
          end, :),))
```

But those gensyms won't be liked by the doctests.  Any idea how to nicely add it?

@torfjelde check it out.