### PR TITLE
Using Setfield.jl's lenses to handle indexing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "7a57a42e-76ec-4ea3-a279-07e840d6d9cf"
 keywords = ["probablistic programming"]
 license = "MIT"
 desc = "Common interfaces for probabilistic programming"
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.1.4"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
+Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,6 @@ version = "0.2.0"
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
-StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 AbstractMCMC = "2, 3"

--- a/Project.toml
+++ b/Project.toml
@@ -11,4 +11,5 @@ Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 
 [compat]
 AbstractMCMC = "2, 3"
+Setfield = "0.7.1"
 julia = "1"

--- a/src/AbstractPPL.jl
+++ b/src/AbstractPPL.jl
@@ -7,10 +7,8 @@ export VarName,
     inspace,
     subsumes,
     varname,
-    vinds,
     vsym,
     @varname,
-    @vinds,
     @vsym
 
 

--- a/src/AbstractPPL.jl
+++ b/src/AbstractPPL.jl
@@ -1,22 +1,11 @@
 module AbstractPPL
 
 # VarName
-export VarName,
-    getsym,
-    getindexing,
-    inspace,
-    subsumes,
-    varname,
-    vsym,
-    @varname,
-    @vsym
+export VarName, getsym, getindexing, inspace, subsumes, varname, vsym, @varname, @vsym
 
 
 # Abstract model functions
-export AbstractProbabilisticProgram,
-    condition,
-    decondition,
-    logdensity
+export AbstractProbabilisticProgram, condition, decondition, logdensity
 
 
 # Abstract traces

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -106,7 +106,9 @@ function Base.show(io::IO, vn::VarName{<:Any, <:Lens})
     Setfield.print_application(io, vn.indexing)
 end
 
+# TODO: Should this really go here?
 Setfield.print_application(io::IO, l::IndexLens) = print(io, "[", join(map(prettify_index, l.indices), ", "), "]")
+Setfield.print_application(io::IO, l::DynamicIndexLens) = print(io, l, "(_)")
 
 prettify_index(x) = string(x)
 prettify_index(::Colon) = ":"

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -1,3 +1,5 @@
+using Setfield
+
 """
     VarName{sym}(indexing::Tuple=())
 
@@ -26,10 +28,10 @@ julia> @varname x[:, 1][1+1]
 x[Colon(),1][2]
 ```
 """
-struct VarName{sym, T<:Tuple}
+struct VarName{sym, T}
     indexing::T
 
-    VarName{sym}(indexing::Tuple=()) where {sym} = new{sym,typeof(indexing)}(indexing)
+    VarName{sym}(indexing=()) where {sym} = new{sym,typeof(indexing)}(indexing)
 end
 
 """
@@ -89,13 +91,18 @@ getindexing(vn::VarName) = vn.indexing
 Base.hash(vn::VarName, h::UInt) = hash((getsym(vn), getindexing(vn)), h)
 Base.:(==)(x::VarName, y::VarName) = getsym(x) == getsym(y) && getindexing(x) == getindexing(y)
 
-function Base.show(io::IO, vn::VarName)
+function Base.show(io::IO, vn::VarName{<:Any, <:Tuple})
     print(io, getsym(vn))
     for indices in getindexing(vn)
         print(io, "[")
         join(io, indices, ",")
         print(io, "]")
     end
+end
+
+function Base.show(io::IO, vn::VarName{<:Any, <:Lens})
+    print(io, getsym(vn))
+    Setfield.print_application(io, vn.indexing)
 end
 
 

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -493,34 +493,6 @@ function drop_escape(expr::Expr)
     return Expr(expr.head, map(x -> drop_escape(x), expr.args)...)
 end
 
-@static if VERSION ≥ v"1.5.0-DEV.666"
-    # TODO: Replace once https://github.com/jw3126/Setfield.jl/pull/155 has been merged.
-    function Setfield.lower_index(collection::Symbol, index, dim)
-        if Setfield.isexpr(index, :call)
-            return Expr(:call, Setfield.lower_index.(collection, index.args, dim)...)
-        elseif (index === :end)
-            if dim === nothing
-                return :($(Base.lastindex)($collection))
-            else
-                return :($(Base.lastindex)($collection, $dim))
-            end
-        elseif index === :begin
-            if dim === nothing
-                return :($(Base.firstindex)($collection))
-            else
-                return :($(Base.firstindex)($collection, $dim))
-            end
-        end
-        return index
-    end
-
-    function Setfield.need_dynamic_lens(ex)
-        return Setfield.foldtree(false, ex) do yes, x
-            (yes || x === :end || x === :begin || x === :_)
-        end
-    end
-end
-
 """
     @vsym(expr)
 

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -88,6 +88,24 @@ julia> getindexing(@varname(y))
 """
 getindexing(vn::VarName) = vn.indexing
 
+"""
+    get(obj, vn::VarName{sym})
+
+Alias for `get(obj, PropertyLens{sym}() ∘ vn.indexing)`.
+"""
+function Setfield.get(obj, vn::VarName{sym}) where {sym}
+    return Setfield.get(obj, PropertyLens{sym}() ∘ vn.indexing)
+end
+
+"""
+    set(obj, vn::VarName{sym}, value)
+
+Alias for `set(obj, PropertyLens{sym}() ∘ vn.indexing, value)`.
+"""
+function Setfield.set(obj, vn::VarName{sym}, value) where {sym}
+    return Setfield.set(obj, PropertyLens{sym}() ∘ vn.indexing, value)
+end
+
 
 Base.hash(vn::VarName, h::UInt) = hash((getsym(vn), getindexing(vn)), h)
 Base.:(==)(x::VarName, y::VarName) = getsym(x) == getsym(y) && getindexing(x) == getindexing(y)

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -336,9 +336,12 @@ x.a[1,2][:]
 concretize(vn::VarName, x) = VarName(vn, concretize(vn.indexing, x))
 
 """
-    @varname(expr)
+    @varname(expr[, concretize])
 
 A macro that returns an instance of [`VarName`](@ref) given a symbol or indexing expression `expr`.
+
+If `concretize` is `true`, the resulting expression will be wrapped in a [`concretize`](@ref) call.
+This is useful if you for example want to ensure that no `Setfield.DynamicLens` is used.
 
 The `sym` value is taken from the actual variable name, and the index values are put appropriately
 into the constructor (and resolved at runtime).
@@ -367,7 +370,7 @@ julia> @varname(x[1,2][1+5][45][3]).indexing
     Julia 1.5.
 """
 macro varname(expr::Union{Expr, Symbol}, concretize=false)
-    return varname(expr, concretize=concretize)
+    return varname(expr, concretize)
 end
 
 varname(sym::Symbol, concretize=false) = :($(AbstractPPL.VarName){$(QuoteNode(sym))}())

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -20,13 +20,13 @@ indexing expression through the [`@varname`](@ref) convenience macro.
 
 ```jldoctest
 julia> vn = VarName{:x}(((Colon(), 1), (2,)))
-x[:, 1][2]
+x[:,1][2]
 
 julia> vn.indexing
 ((Colon(), 1), (2,))
 
 julia> @varname x[:, 1][1+1]
-x[:, 1][2]
+x[:,1][2]
 ```
 """
 struct VarName{sym, T}
@@ -80,7 +80,7 @@ Return the indexing tuple of the Julia variable used to generate `vn`.
 
 ```jldoctest
 julia> getindexing(@varname(x[1][2:3]))
-((1,), (2:3,))
+(@lens _[1][2:3])
 
 julia> getindexing(@varname(y))
 ()
@@ -326,15 +326,15 @@ Return `vn` instantiated on `x`, i.e. any runtime information evaluated using `x
 julia> x = (a = [1.0 2.0;], );
 
 julia> vn = @varname(x.a[1, :])
-x.a[1, :]
+x.a[1,:]
 
 julia> AbstractPPL.concretize(vn, x)
-x.a[1, :]
+x.a[1,:]
 
 julia> vn = @varname(x.a[1, end][:]);
 
 julia> AbstractPPL.concretize(vn, x)
-x.a[1, 2][:]
+x.a[1,2][:]
 ```
 """
 concretize(vn::VarName, x) = VarName(vn, concretize(vn.indexing, x))
@@ -357,10 +357,10 @@ julia> @varname(x[1]).indexing
 (@lens _[1])
 
 julia> @varname(x[:, 1]).indexing
-(@lens _[:, 1])
+(@lens _[Colon(), 1])
 
 julia> @varname(x[:, 1][2]).indexing
-(@lens _[:, 1][2])
+(@lens _[Colon(), 1][2])
 
 julia> @varname(x[1,2][1+5][45][3]).indexing
 (@lens _[1, 2][6][45][3])

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -267,6 +267,22 @@ end
     concretize(vn::VarName, x)
 
 Return `vn` instantiated on `x`, i.e. any runtime information evaluated using `x`.
+
+# Examples
+```jldoctest
+julia> x = (a = [1.0 2.0;], );
+
+julia> vn = @varname(x.a[1, :])
+x.a[1, :]
+
+julia> AbstractPPL.concretize(vn, x)
+x.a[1, :]
+
+julia> vn = @varname(x.a[1, end][:]);
+
+julia> AbstractPPL.concretize(vn, x)
+x.a[1, 2][:]
+```
 """
 concretize(vn::VarName, x) = VarName(vn, concretize(vn.indexing, x))
 
@@ -285,16 +301,16 @@ julia> @varname(x).indexing
 ()
 
 julia> @varname(x[1]).indexing
-((1,),)
+(@lens _[1])
 
 julia> @varname(x[:, 1]).indexing
-((Colon(), 1),)
+(@lens _[:, 1])
 
 julia> @varname(x[:, 1][2]).indexing
-((Colon(), 1), (2,))
+(@lens _[:, 1][2])
 
 julia> @varname(x[1,2][1+5][45][3]).indexing
-((1, 2), (6,), (45,), (3,))
+(@lens _[1, 2][6][45][3])
 ```
 
 !!! compat "Julia 1.5"

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -92,6 +92,11 @@ getindexing(vn::VarName) = vn.indexing
 Base.hash(vn::VarName, h::UInt) = hash((getsym(vn), getindexing(vn)), h)
 Base.:(==)(x::VarName, y::VarName) = getsym(x) == getsym(y) && getindexing(x) == getindexing(y)
 
+# Composition rules similar to the standard one for lenses, but we need a special
+# one for the "empty" `VarName{..., Tuple{}}`.
+Base.:∘(vn::VarName{sym,Tuple{}}, lens::Lens) where {sym} = VarName{sym}(lens)
+Base.:∘(vn::VarName{sym,<:Lens}, lens::Lens) where {sym} = VarName{sym}(vn.indexing ∘ lens)
+
 function Base.show(io::IO, vn::VarName{<:Any, <:Tuple})
     print(io, getsym(vn))
     for indices in getindexing(vn)

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -128,15 +128,6 @@ Base.:(==)(x::VarName, y::VarName) = getsym(x) == getsym(y) && getindexing(x) ==
 Base.:∘(vn::VarName{sym,<:IdentityLens}, lens::Lens) where {sym} = VarName{sym}(lens)
 Base.:∘(vn::VarName{sym,<:Lens}, lens::Lens) where {sym} = VarName{sym}(vn.indexing ∘ lens)
 
-function Base.show(io::IO, vn::VarName{<:Any, <:Tuple})
-    print(io, getsym(vn))
-    for indices in getindexing(vn)
-        print(io, "[")
-        join(io, map(prettify_index, indices), ",")
-        print(io, "]")
-    end
-end
-
 function Base.show(io::IO, vn::VarName{<:Any, <:Lens})
     print(io, getsym(vn))
     _print_application(io, vn.indexing)

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -172,7 +172,7 @@ Base.Symbol(vn::VarName) = Symbol(string(vn))  # simplified symbol
     inspace(vn::Union{VarName, Symbol}, space::Tuple)
 
 Check whether `vn`'s variable symbol is in `space`.  The empty tuple counts as the "universal space"
-containing all variables.  Subsumption (see [`subsume`](@ref)) is respected.
+containing all variables. Subsumption (see [`subsume`](@ref)) is respected.
 
 ## Examples
 
@@ -389,11 +389,11 @@ const ConcreteIndex = Union{Int, AbstractVector{Int}} # this include all kinds o
 """Determine whether indices `i` are contained in `j`, treating `:` as universal set."""
 _issubrange(i::ConcreteIndex, j::ConcreteIndex) = issubset(i, j)
 _issubrange(i::Colon, j::Colon) = true
-_issubrange(i::Colon, j::ConcreteIndex) = false
+_issubrange(i::ConcreteIndex, j::Colon) = true
 # FIXME: [2021-07-31] This is wrong but we have tests in DPPL that tell
 # us that it SHOULD be correct. I'll leave it as is for now to ensure that
 # we preserve the status quo, but I'm confused.
-_issubrange(i::ConcreteIndex, j::Colon) = false
+_issubrange(i::Colon, j::ConcreteIndex) = true
 
 """
     concretize(l::Lens, x)

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -103,12 +103,22 @@ end
 
 function Base.show(io::IO, vn::VarName{<:Any, <:Lens})
     print(io, getsym(vn))
-    Setfield.print_application(io, vn.indexing)
+    _print_application(io, vn.indexing)
 end
 
-# TODO: Should this really go here?
-Setfield.print_application(io::IO, l::IndexLens) = print(io, "[", join(map(prettify_index, l.indices), ", "), "]")
-Setfield.print_application(io::IO, l::DynamicIndexLens) = print(io, l, "(_)")
+_print_application(io::IO, l::Lens) = Setfield.print_application(io, l)
+function _print_application(io::IO, l::ComposedLens)
+    _print_application(io, l.outer)
+    _print_application(io, l.inner)
+end
+function _print_application(io::IO, l::ComposedLens{})
+    _print_application(io, l.outer)
+    _print_application(io, l.inner)
+end
+_print_application(io::IO, l::IndexLens) = print(io, "[", join(map(prettify_index, l.indices), ","), "]")
+# This is a bit weird but whatever. We're almost always going to
+# `concretize` anyways.
+_print_application(io::IO, l::DynamicIndexLens) = print(io, l, "(_)")
 
 prettify_index(x) = string(x)
 prettify_index(::Colon) = ":"

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -492,7 +492,7 @@ julia> @vinds x[2:3,2:3][[1,2],[1,2]]
     Julia 1.5.
 """
 macro vinds(expr::Union{Expr, Symbol})
-    return esc(vinds(expr))
+    return vinds(expr)
 end
 
 
@@ -523,7 +523,7 @@ function vinds(expr::Expr)
         else
             Base.replace_ref_begin_end!(ex)
         end
-        last = esc(Expr(:tuple, ex.args[2:end]...))
+        last = Expr(:tuple, ex.args[2:end]...)
         init = vinds(ex.args[1]).args
         return Expr(:tuple, init..., last)
     else

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -324,11 +324,12 @@ end
 varname(sym::Symbol) = :($(AbstractPPL.VarName){$(QuoteNode(sym))}())
 function varname(expr::Expr)
     if Meta.isexpr(expr, :ref) || Meta.isexpr(expr, :.)
-        sym = vsym(expr)
+        expr_new = deepcopy(expr)
+        sym = vsym(expr_new)
 
         # Need to recursively unwrap until we reach the outer-most variable.
         # TODO: implement as recursion?
-        curexpr = expr
+        curexpr = expr_new
         while !(curexpr.args[1] isa Symbol)
             curexpr = curexpr.args[1]
         end
@@ -336,7 +337,7 @@ function varname(expr::Expr)
         # Then we replace the variable with `_`, to get an expression we can
         # use `lensmacro` on.
         curexpr.args[1] = :_
-        inds = Setfield.lensmacro(identity, expr)
+        inds = Setfield.lensmacro(identity, expr_new)
 
         return :($(AbstractPPL.VarName){$(QuoteNode(sym))}($inds))
     else

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -1,5 +1,5 @@
 using Setfield
-import Setfield: PropertyLens, ComposedLens, IdentityLens, IndexLens, DynamicIndexLens
+using Setfield: PropertyLens, ComposedLens, IdentityLens, IndexLens, DynamicIndexLens
 
 """
     VarName{sym}(indexing::Tuple=())

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -358,8 +358,11 @@ const ConcreteIndex = Union{Int, AbstractVector{Int}} # this include all kinds o
 """Determine whether indices `i` are contained in `j`, treating `:` as universal set."""
 _issubrange(i::ConcreteIndex, j::ConcreteIndex) = issubset(i, j)
 _issubrange(i::Colon, j::Colon) = true
+_issubrange(i::Colon, j::ConcreteIndex) = false
+# FIXME: [2021-07-31] This is wrong but we have tests in DPPL that tell
+# us that it SHOULD be correct. I'll leave it as is for now to ensure that
+# we preserve the status quo, but I'm confused.
 _issubrange(i::ConcreteIndex, j::Colon) = false
-_issubrange(i::Colon, j::ConcreteIndex) = true
 
 """
     concretize(l::Lens, x)

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -455,12 +455,12 @@ julia> @varname(x[1,2][1+5][45][3]).indexing
     Using `begin` in an indexing expression to refer to the first index requires at least
     Julia 1.5.
 """
-macro varname(expr::Union{Expr, Symbol}, concretize=false)
+macro varname(expr::Union{Expr, Symbol}, concretize::Bool=false)
     return varname(expr, concretize)
 end
 
-varname(sym::Symbol, concretize=false) = :($(AbstractPPL.VarName){$(QuoteNode(sym))}())
-function varname(expr::Expr, concretize=false)
+varname(sym::Symbol, concretize::Bool=false) = :($(AbstractPPL.VarName){$(QuoteNode(sym))}())
+function varname(expr::Expr, concretize::Bool=false)
     if Meta.isexpr(expr, :ref) || Meta.isexpr(expr, :.)
         # Split into object/base symbol and lens.
         sym_escaped, lens = Setfield.parse_obj_lens(expr)
@@ -468,7 +468,7 @@ function varname(expr::Expr, concretize=false)
         # to call `QuoteNode` on it.
         sym = drop_escape(sym_escaped)
 
-        return if Setfield.need_dynamic_lens(expr)
+        return if concretize && Setfield.need_dynamic_lens(expr)
             :($(AbstractPPL.concretize)($(AbstractPPL.VarName){$(QuoteNode(sym))}($lens), $sym_escaped))
         else
             :($(AbstractPPL.VarName){$(QuoteNode(sym))}($lens))

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -367,11 +367,11 @@ julia> @varname(x[1,2][1+5][45][3]).indexing
     Julia 1.5.
 """
 macro varname(expr::Union{Expr, Symbol}, concretize=false)
-    return varname(expr; concretize=concretize)
+    return varname(expr, concretize=concretize)
 end
 
-varname(sym::Symbol; concretize=false) = :($(AbstractPPL.VarName){$(QuoteNode(sym))}())
-function varname(expr::Expr; concretize=false)
+varname(sym::Symbol, concretize=false) = :($(AbstractPPL.VarName){$(QuoteNode(sym))}())
+function varname(expr::Expr, concretize=false)
     if Meta.isexpr(expr, :ref) || Meta.isexpr(expr, :.)
         sym = vsym(expr)
         # Convert `expr` into something `lensmacro` can parse.

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -18,8 +18,8 @@ indexing expression through the [`@varname`](@ref) convenience macro.
 
 # Examples
 
-```jldoctest
-julia> vn = VarName{:x}(((Colon(), 1), (2,)))
+```jldoctest; setup=:(using Setfield)
+julia> vn = VarName{:x}(Setfield.IndexLens((Colon(), 1)) ∘ Setfield.IndexLens((2, )))
 x[:,1][2]
 
 julia> vn.indexing

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -450,7 +450,7 @@ function vinds(expr::Expr)
         else
             Base.replace_ref_begin_end!(ex)
         end
-        last = Expr(:tuple, ex.args[2:end]...)
+        last = esc(Expr(:tuple, ex.args[2:end]...))
         init = vinds(ex.args[1]).args
         return Expr(:tuple, init..., last)
     else

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -23,7 +23,7 @@ julia> vn = VarName{:x}(Setfield.IndexLens((Colon(), 1)) ∘ Setfield.IndexLens(
 x[:,1][2]
 
 julia> vn.indexing
-((Colon(), 1), (2,))
+(@lens _[Colon(), 1][2])
 
 julia> @varname x[:, 1][1+1]
 x[:,1][2]
@@ -118,7 +118,7 @@ julia> getindexing(@varname(x[1][2:3]))
 (@lens _[1][2:3])
 
 julia> getindexing(@varname(y))
-()
+(@lens _)
 ```
 """
 getindexing(vn::VarName) = vn.indexing
@@ -322,7 +322,7 @@ e.g. `_[1][2].a[2]` and `_[1][2].a`. In such a scenario we do the following:
    which then returns `false`.
 
 # Example
-```jldoctest; setup=:(using Setfield)
+```jldoctest; setup=:(using Setfield; using AbstractPPL: subsumes_index)
 julia> t = @lens(_[1].a); u = @lens(_[1]);
 
 julia> subsumes_index(t, u)
@@ -438,10 +438,9 @@ Return `vn` instantiated on `x`, i.e. any runtime information evaluated using `x
 
 # Examples
 ```jldoctest; setup=:(using Setfield)
-
 julia> x = (a = [1.0 2.0;], );
 
-julia> AbstractPPL.concretize(@lens(_.a[1, end][:]), x)
+julia> AbstractPPL.concretize(@varname(x.a[1, end][:]), x)
 x.a[1,2][:]
 ```
 """

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -20,13 +20,13 @@ indexing expression through the [`@varname`](@ref) convenience macro.
 
 ```jldoctest
 julia> vn = VarName{:x}(((Colon(), 1), (2,)))
-x[:,1][2]
+x[:, 1][2]
 
 julia> vn.indexing
 ((Colon(), 1), (2,))
 
 julia> @varname x[:, 1][1+1]
-x[:,1][2]
+x[:, 1][2]
 ```
 """
 struct VarName{sym, T}

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -111,10 +111,6 @@ function _print_application(io::IO, l::ComposedLens)
     _print_application(io, l.outer)
     _print_application(io, l.inner)
 end
-function _print_application(io::IO, l::ComposedLens{})
-    _print_application(io, l.outer)
-    _print_application(io, l.inner)
-end
 _print_application(io::IO, l::IndexLens) = print(io, "[", join(map(prettify_index, l.indices), ","), "]")
 # This is a bit weird but whatever. We're almost always going to
 # `concretize` anyways.

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -234,6 +234,7 @@ _issubrange(i::Colon, j::ConcreteIndex) = true
 
 # E.g. `x`, `x[1]`, i.e. `u` is always subsumed by `t`
 subsumes(t::Tuple{}, u::Lens) = true
+subsumes(t::Lens, u::Tuple{}) = false
 
 # Idea behind `subsumes` for `Lens` is that we traverse the two lenses in parallel,
 # checking `subsumes` for every level. This for example means that if we are comparing
@@ -258,7 +259,7 @@ subsumes(t::PropertyLens, u::PropertyLens) = false
 # FIXME: Does not support `DynamicIndexLens`.
 # FIXME: Does not correctly handle cases such as `subsumes(x, x[:])`
 #        (but neither did old implementation).
-subsumes(t::IndexLens, u::IndexLens) = subsumes(t.indices, u.indices)
+subsumes(t::IndexLens, u::IndexLens) = _issubindex(t.indices, u.indices)
 subsumes(t::ComposedLens{<:IndexLens}, u::ComposedLens{<:IndexLens}) = subsumes_index(t, u)
 subsumes(t::IndexLens, u::ComposedLens{<:IndexLens}) = subsumes_index(t, u)
 subsumes(t::ComposedLens{<:IndexLens}, u::IndexLens) = subsumes_index(t, u)

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -33,8 +33,7 @@ struct VarName{sym,T<:Lens}
     indexing::T
 
     function VarName{sym}(indexing=IdentityLens()) where {sym}
-        # TODO: Should we completely disallow or just `@warn`?
-        # TODO: Does this affect performance?
+        # TODO: Should we completely disallow or just `@warn` of limited support?
         if !is_static_lens(indexing)
             error("attempted to construct `VarName` with dynamic lens of type $(nameof(typeof(indexing)))")
         end

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -405,6 +405,7 @@ function drop_escape(expr::Expr)
 end
 
 @static if VERSION ≥ v"1.5.0-DEV.666"
+    # TODO: Replace once https://github.com/jw3126/Setfield.jl/pull/155 has been merged.
     function Setfield.lower_index(collection::Symbol, index, dim)
         if Setfield.isexpr(index, :call)
             return Expr(:call, Setfield.lower_index.(collection, index.args, dim)...)
@@ -428,37 +429,6 @@ end
         return Setfield.foldtree(false, ex) do yes, x
             (yes || x === :end || x === :begin || x === :_)
         end
-    end
-end
-
-"""
-    replace_basesym(expr, sub::Symbol)
-
-Return `expr` with the base symbol replaced, e.g.
-`:(x[1].a[end])` results in `:(\$(sub).[1].a[end])`
-
-# Example
-```jldoctest
-julia> AbstractPPL.replace_basesym(:(x[1].a[end][:]), :_)
-:(((_[1]).a[end])[:])
-
-julia> AbstractPPL.replace_basesym(:(x), :_)
-:x
-
-julia> AbstractPPL.replace_basesym(:(1), :_)
-1
-```
-
-"""
-replace_basesym(x, sub::Symbol) = x
-function replace_basesym(expr::Expr, sub::Symbol)
-    # Recursively replace_basesym the first argument, until the first
-    # argument is a `Symbol`, in which case we replace the first
-    # argument with `:_` and return the expression.
-    return if length(expr.args) > 0 && !(expr.args[1] isa Symbol)
-        Expr(expr.head, replace_basesym(expr.args[1], sub), expr.args[2:end]...)
-    else
-        Expr(expr.head, sub, expr.args[2:end]...)
     end
 end
 

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -37,7 +37,7 @@ end
 
 # A bit of backwards compatibility.
 # TODO: Should we deprecate this?
-VarName{sym}(indexing::Tuple) where {sym} = VarName{sym}(tuple2indexlens(indexing))
+VarName{sym}(indexing::Tuple) where {sym} = VarName{sym}(tupleindex2lens(indexing))
 
 """
     VarName(vn::VarName, indexing::Lens)
@@ -59,12 +59,12 @@ x
 VarName(vn::VarName, indexing::Lens=IdentityLens()) = VarName{getsym(vn)}(indexing)
 
 function VarName(vn::VarName, indexing::Tuple)
-    return VarName{getsym(vn)}(tuple2indexlens(indexing))
+    return VarName{getsym(vn)}(tupleindex2lens(indexing))
 end
 
-tuple2indexlens(indexing::Tuple{}) = IdentityLens()
-tuple2indexlens(indexing::Tuple{<:Tuple}) = IndexLens(first(indexing))
-tuple2indexlens(indexing::Tuple) = IndexLens(first(indexing)) ∘ tuple2indexlens(indexing[2:end])
+tupleindex2lens(indexing::Tuple{}) = IdentityLens()
+tupleindex2lens(indexing::Tuple{<:Tuple}) = IndexLens(first(indexing))
+tupleindex2lens(indexing::Tuple) = IndexLens(first(indexing)) ∘ tupleindex2lens(indexing[2:end])
 
 """
     getsym(vn::VarName)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,7 +1,9 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Documenter = "0.26.3, 0.27"
+Setfield = "0.7.1"
 julia = "1"


### PR DESCRIPTION
Correctly parsing all the `VarName` stuff is _hard_, e.g. https://github.com/TuringLang/AbstractPPL.jl/pull/25, plus we're currently restricted to arrays only.

This PR allows us to defer all the indexing functionality to Setfield.jl's lenses! In addition, it allows us to potentially use `@set` and others within `@model` in DPPL to also support sampling elements of `NamedTuple`, etc.!

The only "major" change is the introduction of `concretize` which we'll have to use in `@model` to address runtime-based indexing, e.g. `x[end]`. But AFAIK this doesn't come at any greater disadvantages than the current impl.

This would address #23 and is further related to https://github.com/TuringLang/Turing.jl/issues/1668 and many other issues/ideas.

```julia
julia> x = (a = [1.0 2.0;], );

julia> vn = @varname(x.a[1, :])
x.a[1, :]

julia> AbstractPPL.concretize(vn, x)
x.a[1, :]

julia> vn = @varname(x.a[1, end][:]);

julia> AbstractPPL.concretize(vn, x)
x.a[1, 2][:]
```

EDIT: You can then do stuff like
```julia
julia> @model function demo(x, y)
           s ~ InverseGamma(2, 3)
           m ~ Normal(0, √s)
           for i in 1:length(x.a) - 1
               x.a[i] ~ Normal(m, √s)
           end

           x.a[end] ~ Normal(100.0, 1.0)
           y.a ~ Normal()
           
           return (; s, m, x, y)
       end
demo (generic function with 2 methods)

julia> struct MyCoolStruct
           a
       end

julia> m = demo(MyCoolStruct([1.0, ]), MyCoolStruct(missing));

julia> m()
(s = 6.097169879128847, m = -5.565352920139915, x = MyCoolStruct([1.0]), y = MyCoolStruct(-0.6953528936398823))

julia> m = demo(MyCoolStruct([1.0, ]), (a = missing, ));

julia> m()
(s = 0.7759718829619909, m = -0.5107335960569337, x = MyCoolStruct([1.0]), y = (a = 2.8120990475668273,))
```

Or we can be a bit mad:

```julia
julia> using DataFrames

julia> using Setfield: ConstructionBase

julia> function ConstructionBase.setproperties(df::DataFrame, patch::NamedTuple)
           # Only need `copy` because we'll replace entire columns
           columns = copy(DataFrames._columns(df))
           colindex = DataFrames.index(df)
           for k in keys(patch)
               columns[colindex[k]] = patch[k]
           end
           return DataFrame(columns, colindex)
       end

julia> @model function demo(x)
           s ~ InverseGamma(2, 3)
           m ~ Normal(0, √s)
           for i in 1:length(x.a) - 1
               x.a[i] ~ Normal(m, √s)
           end

           x.a[end] ~ Normal(100.0, 1.0)
           
           return x
       end
demo (generic function with 1 method)

julia> m = demo(df, (a = missing, ));

julia> m()
3×1 DataFrame
 Row │ a        
     │ Float64? 
─────┼──────────
   1 │   1.0
   2 │   2.0
   3 │  99.8838

julia> df
3×1 DataFrame
 Row │ a         
     │ Float64?  
─────┼───────────
   1 │       1.0
   2 │       2.0
   3 │ missing   

```