### PR TITLE
Adopt DensityInterface.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,6 @@ Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 
 [compat]
 AbstractMCMC = "2, 3"
-DensityInterface = "0.3"
+DensityInterface = "0.4"
 Setfield = "0.7.1, 0.8"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "7a57a42e-76ec-4ea3-a279-07e840d6d9cf"
 keywords = ["probablistic programming"]
 license = "MIT"
 desc = "Common interfaces for probabilistic programming"
-version = "0.3.1"
+version = "0.4"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/Project.toml
+++ b/Project.toml
@@ -7,9 +7,11 @@ version = "0.3.1"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
+DensityInterface = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 
 [compat]
 AbstractMCMC = "2, 3"
+DensityInterface = "0.3"
 Setfield = "0.7.1, 0.8"
 julia = "1"

--- a/interface.md
+++ b/interface.md
@@ -30,7 +30,7 @@ functions
 - `condition(::Model, ::Trace) -> ConditionedModel`
 - `decondition(::ConditionedModel) -> GenerativeModel`
 - `sample(::Model, ::Sampler = Exact(), [Int])` (from `AbstractMCMC.sample`)
-- `logdensityof(::Model, ::Trace)` and `density(::Model, ::Trace)` (from
+- `logdensityof(::Model, ::Trace)` and `densityof(::Model, ::Trace)` (from
   [DensityInterface.jl](https://github.com/JuliaMath/DensityInterface.jl))
 
 
@@ -215,10 +215,11 @@ the concrete model instance.
 
 ```
 DensityInterface.densityof(d, x) = exp(logdensityof(d, x))
-DensityInterface.logdensity(d) = Base.Fix1(logdensity, d)
+DensityInterface.logdensityof(d) = Base.Fix1(logdensityof, d)
+DensityInterface.densityof(d) = Base.Fix1(densityof, d)
 ```
 
-are provided automatically. 
+are provided automatically (repeated here for clarity). 
 
 Note that `logdensityof` strictly generalizes `logpdf`, since the posterior density will of course
 in general be unnormalized and hence not a probability density.

--- a/interface.md
+++ b/interface.md
@@ -210,8 +210,8 @@ therefore adapt the interface of
 `logdensityof` should suffice for variants, with the distinction being made by the capabilities of
 the concrete model instance.
 
- DensityInterface.jl also requires the trait function `hasdensity`, which is set to `true` for the
-`AbstractProbabilisticProgram` type.  Additional functions
+ DensityInterface.jl also requires the trait function `DensityKind`, which is set to `HasDensity()`
+for the `AbstractProbabilisticProgram` type.  Additional functions
 
 ```
 DensityInterface.densityof(d, x) = exp(logdensityof(d, x))

--- a/src/AbstractPPL.jl
+++ b/src/AbstractPPL.jl
@@ -11,9 +11,10 @@ export AbstractProbabilisticProgram, condition, decondition, logdensityof, densi
 # Abstract traces
 export AbstractModelTrace
 
+
 include("varname.jl")
-include("abstractprobprog.jl")
 include("abstractmodeltrace.jl")
+include("abstractprobprog.jl")
 include("deprecations.jl")
 
 end # module

--- a/src/AbstractPPL.jl
+++ b/src/AbstractPPL.jl
@@ -5,7 +5,7 @@ export VarName, getsym, getindexing, getlens, inspace, subsumes, varname, vsym, 
 
 
 # Abstract model functions
-export AbstractProbabilisticProgram, condition, decondition, logdensityof
+export AbstractProbabilisticProgram, condition, decondition, logdensityof, densityof
 
 
 # Abstract traces

--- a/src/AbstractPPL.jl
+++ b/src/AbstractPPL.jl
@@ -1,7 +1,7 @@
 module AbstractPPL
 
 # VarName
-export VarName, getsym, getindexing, getlens, inspace, subsumes, varname, vsym, @varname, @vsym
+export VarName, getsym, getlens, inspace, subsumes, varname, vsym, @varname, @vsym
 
 
 # Abstract model functions

--- a/src/AbstractPPL.jl
+++ b/src/AbstractPPL.jl
@@ -5,7 +5,7 @@ export VarName, getsym, getindexing, getlens, inspace, subsumes, varname, vsym, 
 
 
 # Abstract model functions
-export AbstractProbabilisticProgram, condition, decondition, logdensity
+export AbstractProbabilisticProgram, condition, decondition, logdensityof
 
 
 # Abstract traces

--- a/src/abstractprobprog.jl
+++ b/src/abstractprobprog.jl
@@ -1,4 +1,5 @@
 using AbstractMCMC
+using DensityInterface
 
 
 """
@@ -8,19 +9,21 @@ Common base type for models expressed as probabilistic programs.
 """
 abstract type AbstractProbabilisticProgram <: AbstractMCMC.AbstractModel end
 
+DensityInterface.hasdensity(::AbstractProbabilisticProgram) = true
+
 
 """
-    logdensity(model, trace)
+    logdensityof(model, trace)
 
 Evaluate the (possibly unnormalized) density of the model specified by the probabilistic program
 in `model`, at specific values for the random variables given through `trace`.
 
 `trace` can be of any supported internal trace type, or a fixed probability expression.
 
-`logdensity` should interact with conditioning and deconditioning in the way required by probability
-theory.
+`logdensityof` should interact with conditioning and deconditioning in the way required by
+probability theory.
 """
-function logdensity end
+DensityInterface.logdensityof
 
 
 """

--- a/src/abstractprobprog.jl
+++ b/src/abstractprobprog.jl
@@ -9,7 +9,7 @@ Common base type for models expressed as probabilistic programs.
 """
 abstract type AbstractProbabilisticProgram <: AbstractMCMC.AbstractModel end
 
-DensityInterface.hasdensity(::AbstractProbabilisticProgram) = true
+DensityInterface.DensityKind(::AbstractProbabilisticProgram) = HasDensity()
 
 
 """

--- a/src/abstractprobprog.jl
+++ b/src/abstractprobprog.jl
@@ -23,7 +23,7 @@ in `model`, at specific values for the random variables given through `trace`.
 `logdensityof` should interact with conditioning and deconditioning in the way required by
 probability theory.
 """
-DensityInterface.logdensityof
+DensityInterface.logdensityof(::AbstractProbabilisticProgram, ::AbstractModelTrace)
 
 
 """

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -120,7 +120,6 @@ julia> getlens(@varname(y))
 """
 getlens(vn::VarName) = vn.lens
 
-@deprecate getindexing(vn::VarName) getlens(vn)
 
 """
     get(obj, vn::VarName{sym})


### PR DESCRIPTION
This is in the hope of finally having a shared logdensity function across "probabilistic packages". Distributions.jl is already pretty much on board, Soss.jl hopefully will join later as soon as questions about how to integrate this with properly done measure theory (implicit/explicit base measures) have been resolved.

The consensus was to let the name be `logdensityof` (and `densityof`) to avoid name clashes. The interface is intended for both types that "have a density" and "are a density". 

The other part of DensityInterface.jl is a trait, `hasdensity`, which for `AbstractProbabilisticModel` I have defaulted to `true`. I think likelihood-free inference is out of scope for the kind of models we target -- is that a reasonable assumption?

See https://github.com/JuliaStats/Distributions.jl/pull/1416, https://github.com/JuliaMath/DensityInterface.jl/issues/1 and https://github.com/JuliaMath/DensityInterface.jl/issues/3. 