### PR TITLE
[Merged by Bors] - moving AbstractContext and evaluate!! to AbstractPPL

### DIFF
--- a/src/AbstractPPL.jl
+++ b/src/AbstractPPL.jl
@@ -5,7 +5,7 @@ export VarName, getsym, getlens, inspace, subsumes, varname, vsym, @varname, @vs
 
 
 # Abstract model functions
-export AbstractProbabilisticProgram, condition, decondition, logdensityof, densityof
+export AbstractProbabilisticProgram, condition, decondition, logdensityof, densityof, AbstractContext, evaluate!!
 
 # Abstract traces
 export AbstractModelTrace

--- a/src/abstractprobprog.jl
+++ b/src/abstractprobprog.jl
@@ -60,3 +60,19 @@ m = decondition(condition(m, obs))
 should hold for generative models `m` and arbitrary `obs`.
 """
 function condition end
+
+""" 
+    AbstractContext
+
+Common base type for Contexts used for dispatching.
+"""
+abstract type AbstractContext end
+
+
+""" 
+    evaluate!!
+
+Sample from the `model` using the `sampler` with random number generator `rng` and the
+`context`, and store the sample and log joint probability in `varinfo`.
+"""
+function evaluate!! end

--- a/src/abstractprobprog.jl
+++ b/src/abstractprobprog.jl
@@ -64,7 +64,7 @@ function condition end
 """ 
     AbstractContext
 
-Common base type for Contexts used for dispatching.
+Common base type for evaluation contexts.
 """
 abstract type AbstractContext end
 

--- a/src/abstractprobprog.jl
+++ b/src/abstractprobprog.jl
@@ -60,10 +60,3 @@ m = decondition(condition(m, obs))
 should hold for generative models `m` and arbitrary `obs`.
 """
 function condition end
-
-""" 
-    AbstractContext
-
-Common base type for evaluation contexts.
-"""
-abstract type AbstractContext end

--- a/src/abstractprobprog.jl
+++ b/src/abstractprobprog.jl
@@ -67,12 +67,3 @@ function condition end
 Common base type for evaluation contexts.
 """
 abstract type AbstractContext end
-
-
-""" 
-    evaluate!!
-
-Sample from the `model` using the `sampler` with random number generator `rng` and the
-`context`, and store the sample and log joint probability in `varinfo`.
-"""
-function evaluate!! end

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -1,0 +1,7 @@
+
+""" 
+evaluate!!
+
+General API for model operations, e.g. prior evaluation, log density, log joint etc.
+"""
+function evaluate!! end

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -1,3 +1,9 @@
+""" 
+    AbstractContext
+
+Common base type for evaluation contexts.
+"""
+abstract type AbstractContext end
 
 """ 
 evaluate!!


### PR DESCRIPTION
Addressing #55 and moving the definitions of `AbstractContext` and `evaluate!!` to AbstractPPL. 