### PR TITLE
[Merged by Bors] - Bugfix for `evaluate!!` and `AbstractContext`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "7a57a42e-76ec-4ea3-a279-07e840d6d9cf"
 keywords = ["probablistic programming"]
 license = "MIT"
 desc = "Common interfaces for probabilistic programming"
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/AbstractPPL.jl
+++ b/src/AbstractPPL.jl
@@ -14,6 +14,7 @@ export AbstractModelTrace
 include("varname.jl")
 include("abstractmodeltrace.jl")
 include("abstractprobprog.jl")
+include("evaluate.jl")
 include("deprecations.jl")
 
 # GraphInfo


### PR DESCRIPTION
They are not defined and hence not actually exported currently. This explains also the test errors in the PRs in DynamicPPL and why the integration test did not complain when these functions were added to AbstractPPL.