### PR TITLE
Fix `logdensityof` mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ functions
 - `condition(::Model, ::Trace) -> ConditionedModel`
 - `decondition(::ConditionedModel) -> GenerativeModel`
 - `sample(::Model, ::Sampler = Exact(), [Int])` (from `AbstractMCMC.sample`)
-- `logdensityof(::Model, ::Trace)` and `densityof(::Model, ::Trace)` (from
+- `logdensity(::Model, ::Trace)` and `density(::Model, ::Trace)` (from
   [DensityInterface.jl](https://github.com/JuliaMath/DensityInterface.jl))
 
 
@@ -231,34 +231,34 @@ to be expressed in the type or dispatch they support, there should be no need fo
 `logjoint`, `loglikelihood`, etc., which force these semantic distinctions on the implementor; we
 therefore adapt the interface of
 [DensityInterface.jl](https://github.com/JuliaMath/DensityInterface.jl).  Its main function
-`logdensityof` should suffice for variants, with the distinction being made by the capabilities of
+`logdensity` should suffice for variants, with the distinction being made by the capabilities of
 the concrete model instance.
 
  DensityInterface.jl also requires the trait function `DensityKind`, which is set to `HasDensity()`
 for the `AbstractProbabilisticProgram` type.  Additional functions
 
 ```
-DensityInterface.densityof(d, x) = exp(logdensityof(d, x))
-DensityInterface.logdensityof(d) = Base.Fix1(logdensityof, d)
+DensityInterface.densityof(d, x) = exp(logdensity(d, x))
+DensityInterface.logdensity(d) = Base.Fix1(logdensity, d)
 DensityInterface.densityof(d) = Base.Fix1(densityof, d)
 ```
 
 are provided automatically (repeated here for clarity). 
 
-Note that `logdensityof` strictly generalizes `logpdf`, since the posterior density will of course
+Note that `logdensity` strictly generalizes `logpdf`, since the posterior density will of course
 in general be unnormalized and hence not a probability density.
 
 The evaluation will usually work with the internal, concrete trace type, like `VarInfo` in
 Turing.jl:
 
 ```julia
-logdensityof(m, vi)
+logdensity(m, vi)
 ```
 
 But the user will more likely work on the interface using probability expressions:
 
 ```julia
-logdensityof(m, @T(X = …))
+logdensity(m, @T(X = …))
 ```
 
 (Note that this would replace the current `prob` string macro in Turing.jl.)
@@ -272,7 +272,7 @@ It should be able to make this fall back on the internal method with the right d
 implementation of `maketrace`:
 
 ```julia
-logdensityof(m, t::ProbabilityExpression) = logdensityof(m, maketrace(m, t))
+logdensity(m, t::ProbabilityExpression) = logdensity(m, maketrace(m, t))
 ```
 
 There is one open question – should normalized and unnormalized densities be able to be
@@ -280,7 +280,7 @@ distinguished?  This could be done by dispatch as well, e.g., if the caller want
 normalization:
 
 ```
-logdensityof(g, @T(X = …, Y = …, Z = …); normalized=Val{true})
+logdensity(g, @T(X = …, Y = …, Z = …); normalized=Val{true})
 ```
 
 Although there is proably a better way through traits; maybe like for arrays, with


### PR DESCRIPTION
I suspect `logdensityof` is supposed to be `logdensity`, as I don't see any `logdensityof` function.