### PR TITLE
Add StatsBase.predict to the interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,9 +11,11 @@ DensityInterface = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 AbstractMCMC = "2, 3, 4"
 DensityInterface = "0.4"
 Setfield = "0.8.2, 1"
+StatsBase = "0.32, 0.33"
 julia = "~1.6.6, 1.7.3"

--- a/src/abstractprobprog.jl
+++ b/src/abstractprobprog.jl
@@ -1,6 +1,7 @@
 using AbstractMCMC
 using DensityInterface
 using Random
+using StatsBase
 
 
 """
@@ -79,4 +80,30 @@ function Base.rand(::Type{T}, model::AbstractProbabilisticProgram) where {T}
 end
 function Base.rand(model::AbstractProbabilisticProgram)
     return rand(Random.default_rng(), NamedTuple, model)
+end
+
+"""
+    predict(
+        [rng::AbstractRNG=Random.default_rng(),]
+        [T=NamedTuple,]
+        model::AbstractProbabilisticProgram,
+        params,
+    ) -> T
+
+Draw a sample from the joint distribution specified by `model` conditioned on the values in
+`params`.
+
+The sample will be returned as format specified by `T`.
+"""
+function StatsBase.predict(rand::AbstractRNG, T::Type, model::AbstractProbabilisticProgram, params)
+    return rand(rng, T, condition(model, params))
+end
+function StatsBase.predict(T::Type, model::AbstractProbabilisticProgram, params)
+    return StatsBase.predict(Random.default_rng(), T, model, params)
+end
+function StatsBase.predict(model::AbstractProbabilisticProgram, params)
+    return StatsBase.predict(NamedTuple, model, params)
+end
+function StatsBase.predict(rng::AbstractRNG, params)
+    return StatsBase.predict(rng, NamedTuple, model, params)
 end


### PR DESCRIPTION
As suggested in https://github.com/TuringLang/DynamicPPL.jl/issues/466#issuecomment-1436670214, this PR adds `StatsBase.predict` to the API with a default implementation.