### PR TITLE
Stripe `identity` off `ComposedOptic` when test equality

### DIFF
--- a/test/varname.jl
+++ b/test/varname.jl
@@ -56,6 +56,13 @@ end
         vn3 = VarName{:a}(identity ∘ IndexLens(1))
         @test vn1 == vn2
         @test vn1 == vn3
+
+        vn4 = VarName{:a}(identity ∘ PropertyLens{:b}() ∘ (IndexLens(1) ∘ identity))
+        vn5 = VarName{:a}(PropertyLens{:b}() ∘ IndexLens(1))
+        @test vn4 == vn5
+
+        d = Dict(vn4 => 1)
+        @test d[vn5] == 1
     end
 
     @testset "get & set" begin


### PR DESCRIPTION
The method 
```julia
function Base.:∘(vn::VarName{sym,<:Lens}, lens::Lens) where {sym}
    return VarName{sym}(getlens(vn) ∘ lens)
end
```
was removed with the #91. 

The trigger was: `Accessors` changes the order of composition (`Accessors` follows function composition order, i.e., `f ∘ g` mean apply `g` first, which I think is more intuitive), so we needed to adjust the above function for the new order or remove it. 
With my personal taste, I removed it (sorry for missing @torfjelde's comment [here](https://github.com/TuringLang/AbstractPPL.jl/pull/91#discussion_r1532153556)), because it strikes me a bit strange composing a `VarName` and an `optic`. 

WIthout this function, In DynamicPPL, we will need to do something like `VarName{getsym(vn)}(optic ∘ getoptic(vn))` explicitly, which works okay (modulo the extra code). (One current [example ](https://github.com/TuringLang/DynamicPPL.jl/blob/0787ed2d5fb565c38186b8ec28ee85d5f2aad4e0/src/compiler.jl#L228-L230) in `DynamicPPL` using `∘` between `VarName` and `Lens`.)

But one issue surface:
Sometimes in `DynamicPPL` we need to retrieve a value from a dictionary like `Dict(VarName{:a}(IndexLens(1)) => 1.0, ...)`, with varname `
VarName{:a}(IndexLens(1) ∘ identity)`. Just as Tor's concern, this will fail. 

This PR implements a more allowing equality tests to circumvent this issue. But I am also happy to consider restoring the aforementioned `Base.:∘(vn::VarName{sym,<:Lens}, lens::Lens)` function.