### PR TITLE
Fix optic parsing function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "7a57a42e-76ec-4ea3-a279-07e840d6d9cf"
 keywords = ["probablistic programming"]
 license = "MIT"
 desc = "Common interfaces for probabilistic programming"
-version = "0.8.3"
+version = "0.8.4"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/varname.jl
+++ b/src/varname.jl
@@ -665,7 +665,7 @@ end
 
 function _parse_obj_optic(ex)
     obj, optics = _parse_obj_optics(ex)
-    optic = Expr(:call, :(Accessors.opticcompose), optics...)
+    optic = Expr(:call, Accessors.opticcompose, optics...)
     obj, optic
 end
 


### PR DESCRIPTION
Current master branch:
```julia
julia> @macroexpand @varname(x[1])
:((VarName){:x}((AbstractPPL.Accessors).opticcompose((Accessors.IndexLens)((1,)))))
```

this branch
```julia
julia> @macroexpand @varname(x[1])
:((VarName){:x}((Accessors.opticcompose)((Accessors.IndexLens)((1,)))))
```
which is the right behavior and same to that with `Setfield`. Also ref https://github.com/JuliaObjects/Accessors.jl/blob/01528a81fdf17c07436e1f3d99119d3f635e4c26/src/sugar.jl#L271. 

This should fix the exposure of `Accessors` issues blocking https://github.com/TuringLang/DynamicPPL.jl/pull/585.