### PR TITLE
fix varname_..._leaves for other types

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## 0.13.5
+
+Implemented a generic `varname_leaves` and `varname_and_value_leaves` for other unsupported types.
+
 ## 0.13.4
 
 Added missing methods for `subsumes(::IndexLens, ::PropertyLens)` and vice versa.

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "7a57a42e-76ec-4ea3-a279-07e840d6d9cf"
 keywords = ["probablistic programming"]
 license = "MIT"
 desc = "Common interfaces for probabilistic programming"
-version = "0.13.4"
+version = "0.13.5"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/varname/leaves.jl
+++ b/src/varname/leaves.jl
@@ -65,6 +65,8 @@ function varname_leaves(vn::VarName, x::LinearAlgebra.UpperTriangular)
         VarName{getsym(vn)}(Accessors.IndexLens(Tuple(I)) ∘ getoptic(vn))
     end
 end
+# This is a default fallback for types that we don't know how to handle.
+varname_leaves(vn::VarName, @nospecialize(::Any)) = [vn]
 
 """
     varname_and_value_leaves(vn::VarName, val)
@@ -259,3 +261,5 @@ function varname_and_value_leaves_inner(vn::VarName, x::LinearAlgebra.UpperTrian
         for I in CartesianIndices(x) if I[1] <= I[2]
     )
 end
+# This is a default fallback for types that we don't know how to handle.
+varname_and_value_leaves_inner(vn::VarName, @nospecialize(x::Any)) = [Leaf(vn, x)]

--- a/test/varname.jl
+++ b/test/varname.jl
@@ -423,5 +423,16 @@ end
                 (@varname(x.U[2, 2]), x.U[2, 2]),
             ])
         end
+
+        @testset "fallback on other types, e.g. string" begin
+            x = "a string"
+            @test Set(varname_leaves(@varname(x), x)) == Set([@varname(x)])
+            @test Set(collect(varname_and_value_leaves(@varname(x), x))) ==
+                Set([(@varname(x), x)])
+            x = 2
+            @test Set(varname_leaves(@varname(x), x)) == Set([@varname(x)])
+            @test Set(collect(varname_and_value_leaves(@varname(x), x))) ==
+                Set([(@varname(x), x)])
+        end
     end
 end


### PR DESCRIPTION
This means that AbstractPPL / DynamicPPL don't fall over for variables with non-standard types. For example, if you have the value of `@varname(s)` being `"a string"` then calling `varname_leaves` on this value would crash, which this PR fixes.

Essentially this makes it possible (or perhaps less impossible, since I recognise there are also more problems in DynamicPPL and eltype of varinfo) to have values of arbitrary types in models (which I would point out is especially useful for `:=`).