### PR TITLE
Release prep for 0.15.5: HISTORY.md entry

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## 0.15.5
+
+Widened the `Mooncake` compat bound to `0.5.27, 0.6` (#180). Mooncake 0.6 is a breaking release (forward-mode redesign), but the reverse-mode rule API and the prepared-cache API `AbstractPPLMooncakeExt` uses (`prepare_gradient_cache`, `prepare_derivative_cache`, `prepare_hessian_cache`, `value_and_gradient!!`, `value_gradient_and_hessian!!`, `AutoMooncake`, `AutoMooncakeForward`) are unchanged, so the extension works as-is.
+
 ## 0.15.4
 
 `value_and_gradient!!`, `value_and_jacobian!!`, and `value_gradient_and_hessian!!` now accept a `context=` keyword that overrides, for a single call, the `context` frozen at `prepare` — without re-preparing (#167). The default (`context=nothing`) leaves the hot path unchanged; a `Tuple` override must match the frozen context's element types and shapes — a type mismatch (or a non-`Tuple` override) throws an `ArgumentError` — and reuses the type-keyed cache. Backends that bake context into their prepared state throw an `ArgumentError` for a non-empty-input override (re-`prepare` instead): compiled-tape ReverseDiff (`AutoReverseDiff(; compile=true)`) on all three entry points, and Mooncake's Hessian; Mooncake Jacobian preps are context-free by construction, so only an empty override validates there. Empty input runs no derivative machinery, so no backend rejects an override there (it is still validated).

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -11,7 +11,7 @@ AbstractPPL = {path = ".."}
 
 [compat]
 ADTypes = "1.22.0"
-AbstractPPL = "0.15.4"
+AbstractPPL = "0.15.5"
 Distributions = "0.25.126"
 Documenter = "1.17.0"
 ForwardDiff = "1.4.1"

--- a/test/ext/differentiationinterface/Project.toml
+++ b/test/ext/differentiationinterface/Project.toml
@@ -9,7 +9,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 ADTypes = "1"
-AbstractPPL = "0.15.4"
+AbstractPPL = "0.15.5"
 DifferentiationInterface = "0.6, 0.7"
 ForwardDiff = "1"
 ReverseDiff = "1"

--- a/test/ext/forwarddiff/Project.toml
+++ b/test/ext/forwarddiff/Project.toml
@@ -8,7 +8,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 ADTypes = "1"
-AbstractPPL = "0.15.4"
+AbstractPPL = "0.15.5"
 DiffResults = "1"
 ForwardDiff = "0.10, 1"
 julia = "1.10"

--- a/test/ext/mooncake/Project.toml
+++ b/test/ext/mooncake/Project.toml
@@ -8,6 +8,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 ADTypes = "1"
-AbstractPPL = "0.15.4"
+AbstractPPL = "0.15.5"
 Mooncake = "0.5.27, 0.6"
 julia = "1.10"


### PR DESCRIPTION
Follow-up to #180 ("Allow Mooncake 0.6"), which bumped the version but left HISTORY.md at 0.15.4. Added the entry, and bumped the self-referential AbstractPPL = "0.15.4" pins in docs and the ext test projects to 0.15.5 to match. Verified docs and all three ext tests (forwarddiff, differentiationinterface, mooncake) still pass.